### PR TITLE
docs(Translation.md): hook is "ilgak", but we choose only "ho'k" version

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -17,7 +17,7 @@ https://github.com/reactjs/uz.reactjs.org/issues/1
 | bundler | bandler |
 | callback | kolbek |
 | camelCase | *camelCase* |
-| class component | sinf komponentasi, class komponent |
+| class component | class komponent |
 | (un)controlled component | boshqaril(may)adigan komponent |
 | debugging | debag qilish |
 | DOM container | DOM-konteyner |
@@ -27,7 +27,7 @@ https://github.com/reactjs/uz.reactjs.org/issues/1
 | development mode | dasturlash rejimi |
 | framework | freymvork |
 | function component | funksiyali komponent |
-| hook | ho'k, ilgak |
+| hook | ho'k |
 | incapsulation | inkapsulyatsiya |
 | incapsulated | inkapsulyatsiya qilingan |
 | key | kalit |


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
